### PR TITLE
Parse PE/COFF internally and remove dumpbin.exe requirement on Windows

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,0 +1,89 @@
+name: cygwin
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: /cygdrive/c/cx/lib/perl5
+  PERL_LOCAL_LIB_ROOT: /cygdrive/cx
+  PERL_MB_OPT: --install_base /cygdrive/c/cx
+  PERL_MM_OPT: INSTALL_BASE=/cygdrive/c/cx
+  ALIEN_BUILD_PLUGIN_PKGCONFIG_COMMANDLINE_TEST: 1 # Test Alien::Build::Plugin::PkgConfig::CommandLine
+  CYGWIN_NOWINPATH: 1
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+        shell: powershell
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Cygwin
+        uses: egor-tensin/setup-cygwin@v3
+        with:
+          platform: x64
+          packages: make perl gcc-core gcc-g++ pkg-config libcrypt-devel libssl-devel git
+
+      - name: perl -V
+        run: |
+          perl -V
+          gcc --version
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          gcc --version >> perlversion.txt
+          ls perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: c:\cx
+          key: ${{ runner.os }}-build-cygwin-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-cygwin-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Static Dependencies
+        run: |
+          export PATH="/cygdrive/c/cx/bin:$PATH"
+          cd $( cygpath -u $GITHUB_WORKSPACE )
+          yes | cpan App::cpanminus || true
+          cpanm -n Dist::Zilla
+          perl -S dzil authordeps --missing | perl -S cpanm -n
+          perl -S dzil listdeps --missing   | perl -S cpanm -n
+
+      - name: Install Dynamic Dependencies
+        run: |
+          export PATH="/cygdrive/c/cx/bin:$PATH"
+          cd $( cygpath -u $GITHUB_WORKSPACE )
+          perl -S dzil run --no-build 'perl -S cpanm --installdeps .'
+
+      - name: Run Tests
+        run: |
+          export PATH="/cygdrive/c/cx/bin:$PATH"
+          cd $( cygpath -u $GITHUB_WORKSPACE )
+          perl -S dzil test -v
+
+      - name: CPAN log
+        if: ${{ failure() }}
+        run: |
+          cat ~/.cpanm/latest-build/build.log

--- a/.github/workflows/msys2-mingw.yml
+++ b/.github/workflows/msys2-mingw.yml
@@ -1,0 +1,81 @@
+name: msys2-mingw
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: /c/cx/lib/perl5:/c/cx/lib/perl5/MSWin32-x64-multi-thread
+  PERL_LOCAL_LIB_ROOT: c:/cx
+  PERL_MB_OPT: --install_base C:/cx
+  PERL_MM_OPT: INSTALL_BASE=C:/cx
+  ALIEN_BUILD_PLUGIN_PKGCONFIG_COMMANDLINE_TEST: 1 # Test Alien::Build::Plugin::PkgConfig::CommandLine
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+        shell: powershell
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-perl
+
+      - name: perl -V
+        run: |
+          perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          ls perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: c:\cx
+          key: ${{ runner.os }}-build-msys2-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-msys2-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Static Dependencies
+        run: |
+          export PATH="/c/cx/bin:$PATH"
+          yes | cpan App::cpanminus || true
+          cpanm -n Dist::Zilla
+          perl -S dzil authordeps --missing | perl -S cpanm -n
+          perl -S dzil listdeps --missing   | perl -S cpanm -n
+
+      - name: Install Dynamic Dependencies
+        run: |
+          export PATH="/c/cx/bin:$PATH"
+          perl -S dzil run --no-build 'perl -S cpanm --installdeps .'
+
+      - name: Run Tests
+        run: |
+          export PATH="/c/cx/bin:$PATH"
+          perl -S dzil test -v

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,70 @@
+name: windows
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: c:\cx\lib\perl5
+  PERL_LOCAL_LIB_ROOT: c:/cx
+  PERL_MB_OPT: --install_base C:/cx
+  PERL_MM_OPT: INSTALL_BASE=C:/cx
+
+jobs:
+  perl:
+
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        run: |
+          choco install strawberryperl
+          echo "C:\cx\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\strawberry\c\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\strawberry\perl\site\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-cpan-modules
+        with:
+          path: c:\cx
+          key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: perl -V
+        run: perl -V
+
+      - name: Install Static Dependencies
+        run: |
+          cpanm -n Dist::Zilla
+          dzil authordeps --missing | cpanm -n
+          dzil listdeps --missing   | cpanm -n
+
+      - name: Install Dynamic Dependencies
+        run: dzil run --no-build 'cpanm --installdeps .'
+
+      - name: Run Tests
+        run: dzil test -v
+
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FFI::ExtractSymbols ![linux](https://github.com/PerlFFI/FFI-ExtractSymbols/workflows/linux/badge.svg)
+# FFI::ExtractSymbols ![linux](https://github.com/PerlFFI/FFI-ExtractSymbols/workflows/linux/badge.svg) ![windows](https://github.com/PerlFFI/FFI-ExtractSymbols/workflows/windows/badge.svg) ![cygwin](https://github.com/PerlFFI/FFI-ExtractSymbols/workflows/cygwin/badge.svg) ![msys2-mingw](https://github.com/PerlFFI/FFI-ExtractSymbols/workflows/msys2-mingw/badge.svg)
 
 Extract symbol names from a shared object or DLL
 

--- a/dist.ini
+++ b/dist.ini
@@ -11,7 +11,11 @@ release_tests = 1
 installer     = Author::Plicease::MakeMaker
 irc           = irc://irc.perl.org/#native
 github_user   = PerlFFI
-workflow      = linux
+
+workflow = linux
+workflow = windows
+workflow = cygwin
+workflow = msys2-mingw
 
 [RemovePrereqs]
 remove = strict

--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ File::ShareDir::Dist::Install = 0
 FFI::CheckLib                 = 0
 FFI::Build                    = 0
 File::ShareDir::Dist::Install = 0
+Path::Tiny                    = 0
 
 [Author::Plicease::Upload]
 cpan = 1

--- a/inc/mymm.pl
+++ b/inc/mymm.pl
@@ -10,7 +10,7 @@ sub myWriteMakefile
   my %args = @_;
 
   my $exe = {};
-  foreach my $name (qw( nm objdump dumpbin readelf ))
+  foreach my $name (qw( nm objdump readelf ))
   {
     $exe->{$name} = which($name);
     unless(defined $exe->{$name})
@@ -24,11 +24,6 @@ sub myWriteMakefile
 
   if($^O =~ /^(cygwin|MSWin32)$/)
   {
-    unless(defined $exe->{dumpbin})
-    {
-      print STDERR "dumpbin is required on this platform.\n";
-      exit;
-    }
     install_config_set 'FFI-ExtractSymbols', 'ms_windows' => 1;
   }
   else

--- a/lib/FFI/ExtractSymbols/Windows.pm
+++ b/lib/FFI/ExtractSymbols/Windows.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use File::ShareDir::Dist ();
 use File::Which qw( which );
+use Path::Tiny;
 
 my $config = File::ShareDir::Dist::dist_config('FFI-ExtractSymbols');
 
@@ -29,58 +30,74 @@ instead.
 
 return 1 if FFI::ExtractSymbols->can('extract_symbols') || $^O !~ /^(MSWin32|cygwin)$/;
 
-my $dumpbin = which('dumpbin');
-$dumpbin ||= $config->{'exe'}->{dumpbin};
+$FFI::ExtractSymbols::mode = 'mixed';
 
-if($dumpbin)
+#
+my %sections;
+
+*FFI::ExtractSymbols::extract_symbols = sub
 {
-  # convert path to dumpbin to a spaceless version if it has
-  # spaces
-  $dumpbin = Win32::GetShortPathName($dumpbin) if $dumpbin =~ /\s/;
+  my($libpath, %callbacks) = @_;
+  $callbacks{$_} ||= sub {} for qw( export code data );
 
-  # use forward slashes
-  $dumpbin =~ s{\\}{/}g;
+  my $raw  = Path::Tiny->new($libpath)->slurp_raw;
 
-  # maybe we can tell the difference?
-  # N:\home\ollisg\dev\FFI-ExtractSymbols\.build\PxJz6vIGTh\libtest>dumpbin /symbols cygtest-1.dll|grep my_
-  # 017 00000080 SECT1  notype ()    External     | my_function
-  # 1F8 000001B0 SECT7  notype       External     | my_variable
-  $FFI::ExtractSymbols::mode = 'mixed';
+  #
+  return 1 if 0x5A4D != unpack 'v', substr $raw, 0, 2; # MZ signature failed
+  my $peo = unpack 'V', substr $raw, 0x3C, 4;
+  return 1 if "PE\0\0" ne substr $raw, $peo, 4; # PE signature failed
 
-  *FFI::ExtractSymbols::extract_symbols = sub
+  #
+  my ( $sizeOfOptionalHeader, undef, $magic ) = unpack 'vvv', substr $raw, $peo + 20, 8;
+  return 1 if !$sizeOfOptionalHeader;    # No optional COFF and thus no exports
+  my $pe32plus   = $magic == 0x20b;    # 32bit: Ox10b 64bit: 0x20b ROM?: 0x107
+  my $opt_header = substr $raw, $peo + 24, $sizeOfOptionalHeader;
+
+  # COFF header
+  my $numberOfSections = unpack 'v', substr $raw, $peo + 6, 2;
+
+  # Windows "optional" header
+  my $imageBase = $pe32plus ? unpack 'Q', substr $opt_header, 24, 8 : unpack 'V',
+    substr $opt_header, 28, 4;
+  my $numberOfRVAandSizes = unpack 'V', substr $opt_header, ( $pe32plus ? 108 : 112 ), 4;
   {
-    my($libpath, %callbacks) = @_;
-    $callbacks{$_} ||= sub {} for qw( export code data );
-
-    # dumpbin requires a Windows path, not a POSIX one if you
-    # are running under cygwin
-    $libpath = Cygwin::posix_to_win_path($libpath) if $^O eq 'cygwin';
-
-    # convert path to library to a spaceless version if it has spaces
-    $libpath = Win32::GetShortPathName($libpath) if $libpath =~ /\s/;
-
-    # use forward slashes
-    $libpath =~ s{\\}{/}g;
-
-    foreach my $line (`$dumpbin /exports $libpath`)
-    {
-      # we do not differentiate between code and data
-      # with dumpbin extracts
-      if($line =~ /[0-9]+\s+[0-9]+\s+[0-9a-fA-F]+\s+([^\s]*)\s*$/)
-      {
-        my $symbol = $1;
-        $callbacks{export}->($symbol, $symbol);
-        $callbacks{code}  ->($symbol, $symbol);
-      }
+    %sections = ();
+    my $sec_begin = $peo + 24 + $sizeOfOptionalHeader;
+    my $sec_data  = substr $raw, $sec_begin, $numberOfSections * 40;
+    for my $x ( 0 .. $numberOfSections - 1 ) {
+      my $sec_head = $sec_begin + ( $x * 40 );
+      my $sec_name = unpack 'Z*', substr $raw, $sec_head, 8;
+      $sections{$sec_name} = [ unpack 'VV VVVV vv V', substr $raw, $sec_head + 8 ];
     }
+  }
 
-    ();
-  };
-}
-else
+  # dig into directory
+  my ( $edata_pos, $edata_len ) = unpack 'VV', substr $opt_header, $pe32plus ? 112 : 96, 8;
+  my @fields = unpack 'V10', substr $raw, _rva2offset($edata_pos), 40;
+  my ( $ptr_func, $ptr_name, $ptr_ord ) = map { _rva2offset( $fields[$_] ) } 7 .. 9;
+  my %retval = ( name => unpack 'Z*', substr $raw, _rva2offset( $fields[3] ), 256 );
+  my @ord    = unpack 'V' x $fields[5], substr $raw, $ptr_func, 4 * $fields[5];
+
+  for my $idx ( 0 .. $fields[5] ) {
+    my $ord_cur  = unpack 'v', substr $raw, $ptr_ord + ( 2 * $idx ), 2;
+    my $func_cur = $ord[$ord_cur];    # Match the ordinal to the function RVA
+    next if $idx > ( $fields[6] - 1 );
+    my $name_cur = unpack 'V',  substr $raw, $ptr_name + ( 4 * $idx ), 4;
+    my $symbol = unpack 'Z*', substr $raw, _rva2offset($name_cur), 512;
+    $ord_cur += $fields[4];           # Add the ordinal base value
+    $callbacks{export}->($symbol, $symbol);
+    $callbacks{code}  ->($symbol, $symbol);
+  }
+};
+
+sub _rva2offset
 {
-  die "no implementation for FFI::ExtractSymbols";
+  my ($virtual) = @_;
+  for my $section ( values %sections ) {
+    if ( ( $virtual >= $section->[1] ) and ( $virtual < $section->[1] + $section->[0] ) ) {
+      return $virtual - ( $section->[1] - $section->[3] );
+    }
+  }
 }
-
 
 1;

--- a/lib/FFI/ExtractSymbols/Windows.pm
+++ b/lib/FFI/ExtractSymbols/Windows.pm
@@ -33,8 +33,6 @@ return 1 if FFI::ExtractSymbols->can('extract_symbols') || $^O !~ /^(MSWin32|cyg
 $FFI::ExtractSymbols::mode = 'mixed';
 
 #
-my %sections;
-
 *FFI::ExtractSymbols::extract_symbols = sub
 {
   my($libpath, %callbacks) = @_;
@@ -60,22 +58,20 @@ my %sections;
   my $imageBase = $pe32plus ? unpack 'Q', substr $opt_header, 24, 8 : unpack 'V',
     substr $opt_header, 28, 4;
   my $numberOfRVAandSizes = unpack 'V', substr $opt_header, ( $pe32plus ? 108 : 112 ), 4;
-  {
-    %sections = ();
-    my $sec_begin = $peo + 24 + $sizeOfOptionalHeader;
-    my $sec_data  = substr $raw, $sec_begin, $numberOfSections * 40;
-    for my $x ( 0 .. $numberOfSections - 1 ) {
-      my $sec_head = $sec_begin + ( $x * 40 );
-      my $sec_name = unpack 'Z*', substr $raw, $sec_head, 8;
-      $sections{$sec_name} = [ unpack 'VV VVVV vv V', substr $raw, $sec_head + 8 ];
-    }
+  my $sections; # local cache
+  my $sec_begin = $peo + 24 + $sizeOfOptionalHeader;
+  my $sec_data  = substr $raw, $sec_begin, $numberOfSections * 40;
+  for my $x ( 0 .. $numberOfSections - 1 ) {
+    my $sec_head = $sec_begin + ( $x * 40 );
+    my $sec_name = unpack 'Z*', substr $raw, $sec_head, 8;
+    $sections->{$sec_name} = [ unpack 'VV VVVV vv V', substr $raw, $sec_head + 8 ];
   }
 
   # dig into directory
   my ( $edata_pos, $edata_len ) = unpack 'VV', substr $opt_header, $pe32plus ? 112 : 96, 8;
-  my @fields = unpack 'V10', substr $raw, _rva2offset($edata_pos), 40;
-  my ( $ptr_func, $ptr_name, $ptr_ord ) = map { _rva2offset( $fields[$_] ) } 7 .. 9;
-  my %retval = ( name => unpack 'Z*', substr $raw, _rva2offset( $fields[3] ), 256 );
+  my @fields = unpack 'V10', substr $raw, _rva2offset($edata_pos, $sections), 40;
+  my ( $ptr_func, $ptr_name, $ptr_ord ) = map { _rva2offset( $fields[$_], $sections ) } 7 .. 9;
+  my %retval = ( name => unpack 'Z*', substr $raw, _rva2offset( $fields[3], $sections ), 256 );
   my @ord    = unpack 'V' x $fields[5], substr $raw, $ptr_func, 4 * $fields[5];
 
   for my $idx ( 0 .. $fields[5] ) {
@@ -83,7 +79,7 @@ my %sections;
     my $func_cur = $ord[$ord_cur];    # Match the ordinal to the function RVA
     next if $idx > ( $fields[6] - 1 );
     my $name_cur = unpack 'V',  substr $raw, $ptr_name + ( 4 * $idx ), 4;
-    my $symbol = unpack 'Z*', substr $raw, _rva2offset($name_cur), 512;
+    my $symbol = unpack 'Z*', substr $raw, _rva2offset($name_cur, $sections), 512;
     $ord_cur += $fields[4];           # Add the ordinal base value
     $callbacks{export}->($symbol, $symbol);
     $callbacks{code}  ->($symbol, $symbol);
@@ -92,8 +88,8 @@ my %sections;
 
 sub _rva2offset
 {
-  my ($virtual) = @_;
-  for my $section ( values %sections ) {
+  my ($virtual, $sections) = @_;
+  for my $section ( values %$sections ) {
     if ( ( $virtual >= $section->[1] ) and ( $virtual < $section->[1] + $section->[0] ) ) {
       return $virtual - ( $section->[1] - $section->[3] );
     }

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -18,6 +18,7 @@ $modules{$_} = $_ for qw(
   File::ShareDir::Dist
   File::ShareDir::Dist::Install
   File::Which
+  Path::Tiny
   Test::More
 );
 


### PR DESCRIPTION
I cherry picked #12 and tests are passing on Github Actions and a Windows 10 install I had on an old workstation.